### PR TITLE
Populate list with todo cards

### DIFF
--- a/frontend/src/app/todo-card/todo-card.component.css
+++ b/frontend/src/app/todo-card/todo-card.component.css
@@ -1,0 +1,9 @@
+.clickable-title {
+    text-decoration: none; 
+    cursor: pointer; 
+  }
+  
+  .clickable-title:hover {
+    text-decoration: underline; 
+  }
+  

--- a/frontend/src/app/todo-card/todo-card.component.css
+++ b/frontend/src/app/todo-card/todo-card.component.css
@@ -1,9 +1,28 @@
 .clickable-title {
-    text-decoration: none; 
-    cursor: pointer; 
-  }
-  
-  .clickable-title:hover {
-    text-decoration: underline; 
-  }
-  
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.clickable-title:hover {
+    text-decoration: underline;
+}
+
+.fixed-card-size {
+    width: 350px;
+    height: 220px;
+}
+
+.truncated-title {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    line-clamp: 2;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.expanded-title {
+    height: auto;
+    overflow: visible;
+    white-space: normal;
+}

--- a/frontend/src/app/todo-card/todo-card.component.html
+++ b/frontend/src/app/todo-card/todo-card.component.html
@@ -1,27 +1,50 @@
-<div class="card mt-3 shadow-sm mx-auto" style="max-width: 500px;">
-  <div class="card-body position-relative">
-  
+<div
+  class="card shadow-sm h-100 mx-auto"
+  style="width: 350px; height: 220px;"
+>
+  <div class="card-body position-relative d-flex flex-column">
+    
     @if (todo?.isComplete) {
       <span class="badge text-bg-success rounded-pill position-absolute top-0 end-0 me-3 mt-2">Complete</span>
     }
 
-    <p class="fs-5 text-center mt-4 mb-3"><strong>{{ todo?.title }}</strong></p>
-
-    @if (!todo && !loading) {
-      <div class="alert alert-danger text-center">
-        <p><strong>Error:</strong> Todo not found.</p>
+ 
+    @if (isInList) {
+      <div
+        class="fs-5 text-center mt-4 mb-3 flex-grow-1 text-wrap"
+        style="
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          line-clamp: 2;
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        "
+      >
+        <a
+          class="clickable-title text-dark fw-bold"
+          role="button"
+          (click)="navigateToTodoItem()"
+        >
+          <strong>{{ todo?.title }}</strong>
+        </a>
       </div>
-    } @else if (loading) {
-      <p class="text-center text-muted">Loading...</p>
     } @else {
-      <div class="d-flex justify-content-center gap-3 mt-3">
-        @if (todo?.isComplete) {
-          <button class="btn btn-secondary btn-sm w-25" (click)="toggleComplete()">Incomplete</button>
-        } @else {
-          <button class="btn btn-success btn-sm w-25" (click)="toggleComplete()">Complete</button>
-        }
-        <button class="btn btn-danger btn-sm w-25" (click)="deleteTodo()">Delete</button>
+      <div
+        class="fs-5 text-center mt-4 mb-3 flex-grow-1 text-wrap"
+        style="height: auto; overflow: visible; white-space: normal;"
+      >
+        <strong>{{ todo?.title }}</strong>
       </div>
     }
+
+    <div class="d-flex justify-content-center gap-3 mt-auto">
+      @if (todo?.isComplete) {
+        <button class="btn btn-secondary btn-sm w-50" (click)="toggleComplete()">Incomplete</button>
+      } @else {
+        <button class="btn btn-success btn-sm w-50" (click)="toggleComplete()">Complete</button>
+      }
+      <button class="btn btn-danger btn-sm w-50" (click)="deleteTodo()">Delete</button>
+    </div>
   </div>
 </div>

--- a/frontend/src/app/todo-card/todo-card.component.html
+++ b/frontend/src/app/todo-card/todo-card.component.html
@@ -1,14 +1,13 @@
-
 <div class="card mt-3 shadow-sm mx-auto" style="max-width: 500px;">
   <div class="card-body position-relative">
   
-    @if (todo.isComplete) {
+    @if (todo?.isComplete) {
       <span class="badge text-bg-success rounded-pill position-absolute top-0 end-0 me-3 mt-2">Complete</span>
     }
 
-    <p class="fs-5 text-center mt-4 mb-3"><strong>{{ todo.title }}</strong></p>
+    <p class="fs-5 text-center mt-4 mb-3"><strong>{{ todo?.title }}</strong></p>
 
-    @if (todo.id < 0 && !loading) {
+    @if (!todo && !loading) {
       <div class="alert alert-danger text-center">
         <p><strong>Error:</strong> Todo not found.</p>
       </div>
@@ -16,7 +15,7 @@
       <p class="text-center text-muted">Loading...</p>
     } @else {
       <div class="d-flex justify-content-center gap-3 mt-3">
-        @if (todo.isComplete) {
+        @if (todo?.isComplete) {
           <button class="btn btn-secondary btn-sm w-25" (click)="toggleComplete()">Incomplete</button>
         } @else {
           <button class="btn btn-success btn-sm w-25" (click)="toggleComplete()">Complete</button>
@@ -26,5 +25,3 @@
     }
   </div>
 </div>
-
-<button (click)="navigateToList()" class="btn btn-primary btn-sm">Back to List</button>

--- a/frontend/src/app/todo-card/todo-card.component.html
+++ b/frontend/src/app/todo-card/todo-card.component.html
@@ -1,25 +1,15 @@
-<div
-  class="card shadow-sm h-100 mx-auto"
-  style="width: 350px; height: 220px;"
->
+<div class="card shadow-sm h-100 mx-auto fixed-card-size">
   <div class="card-body position-relative d-flex flex-column">
-    
     @if (todo?.isComplete) {
-      <span class="badge text-bg-success rounded-pill position-absolute top-0 end-0 me-3 mt-2">Complete</span>
+      <span class="badge bg-success rounded-pill position-absolute top-0 end-0 me-3 mt-2">
+        Complete
+      </span>
     }
 
- 
     @if (isInList) {
+      <!-- Multiline title with truncation -->
       <div
-        class="fs-5 text-center mt-4 mb-3 flex-grow-1 text-wrap"
-        style="
-          display: -webkit-box;
-          -webkit-line-clamp: 2;
-          line-clamp: 2;
-          -webkit-box-orient: vertical;
-          overflow: hidden;
-          text-overflow: ellipsis;
-        "
+        class="fs-5 text-center mt-4 mb-3 flex-grow-1 text-wrap truncated-title"
       >
         <a
           class="clickable-title text-dark fw-bold"
@@ -30,10 +20,8 @@
         </a>
       </div>
     } @else {
-      <div
-        class="fs-5 text-center mt-4 mb-3 flex-grow-1 text-wrap"
-        style="height: auto; overflow: visible; white-space: normal;"
-      >
+      <!-- Full title without truncation -->
+      <div class="fs-5 text-center mt-4 mb-3 flex-grow-1 text-wrap expanded-title">
         <strong>{{ todo?.title }}</strong>
       </div>
     }

--- a/frontend/src/app/todo-card/todo-card.component.spec.ts
+++ b/frontend/src/app/todo-card/todo-card.component.spec.ts
@@ -15,15 +15,15 @@ describe('TodoCardComponent', () => {
 
   beforeEach(() => {
     activatedRouteStub = { snapshot: { paramMap: { get: () => '1' } } };
-    routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl']); 
+    routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl']);
 
     TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
       ],
       providers: [
-        TodoCardComponent, 
-        TodoService, 
+        TodoCardComponent,
+        TodoService,
         { provide: ActivatedRoute, useValue: activatedRouteStub },
         { provide: Router, useValue: routerSpy },
       ],
@@ -42,7 +42,7 @@ describe('TodoCardComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should fetch the correct todo on initialization', () => {
+  it('should fetch the correct todo on initialization when no todo is provided', () => {
     const mockTodo: Todo = {
       id: 1, title: 'Todo 1',
       created: new Date(2099, 0, 1),
@@ -61,11 +61,27 @@ describe('TodoCardComponent', () => {
     expect(component.todo).toEqual(mockTodo);
   });
 
+  it('should not fetch data if todo is provided as input', () => {
+    component.todo = {
+      id: 2,
+      title: 'Injected Todo',
+      created: new Date(2099, 0, 1),
+      updated: null,
+      isComplete: false,
+      isDeleted: false
+    };
+
+    component.ngOnInit();
+    httpMock.expectNone(`${environment.apiUrl}/api/todo/2`);
+  });
+
+
   it('should handle an invalid todo ID', () => {
     activatedRouteStub.snapshot.paramMap.get = () => 'invalid';
     component.ngOnInit();
 
-    expect(component.todo.id).toBe(-1);
+    expect(component.todo).toBeUndefined();
+    httpMock.expectNone(`${environment.apiUrl}/api/todo/invalid`);
   });
 
   it('should set loading to false and log error when API returns an error', () => {
@@ -97,11 +113,5 @@ describe('TodoCardComponent', () => {
 
     component.toggleComplete();
     expect(component.todo.isComplete).toBeFalse();
-  });
-
-  it('should navigate back to the todo list when navigateToList() is called', () => {
-    component.navigateToList();
-
-    expect(routerSpy.navigateByUrl).toHaveBeenCalledWith('/todos');
   });
 });

--- a/frontend/src/app/todo-card/todo-card.component.ts
+++ b/frontend/src/app/todo-card/todo-card.component.ts
@@ -10,6 +10,7 @@ import { Todo } from '../_models/todo';
 })
 export class TodoCardComponent implements OnInit {
   @Input() todo?: Todo;
+  @Input() isInList: boolean = false;
   private route = inject(ActivatedRoute);
   private todoService = inject(TodoService);
   private router = inject(Router);
@@ -56,6 +57,12 @@ export class TodoCardComponent implements OnInit {
   deleteTodo() {
     if( this.todo){
       console.log(`Todo #${this.todo.id} marked as deleted`);
+    }
+  }
+
+  navigateToTodoItem() {
+    if (this.todo) {
+      this.router.navigateByUrl(`/todos/${this.todo.id}`);
     }
   }
 }

--- a/frontend/src/app/todo-card/todo-card.component.ts
+++ b/frontend/src/app/todo-card/todo-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, Input, OnInit, inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TodoService } from '../_services/todo.service';
 import { Todo } from '../_models/todo';
@@ -9,26 +9,20 @@ import { Todo } from '../_models/todo';
   styleUrls: ['./todo-card.component.css']
 })
 export class TodoCardComponent implements OnInit {
+  @Input() todo?: Todo;
   private route = inject(ActivatedRoute);
   private todoService = inject(TodoService);
   private router = inject(Router);
   loading: boolean = false;
 
-  todo: Todo = {
-    id: -1,
-    title: "",
-    created: new Date(2099, 0, 1),
-    updated: null,
-    isComplete: false,
-    isDeleted: false
-  };
-
   ngOnInit(): void {
-    const id = this.getValidatedId();
-    if (id === null) {
-      return;
+    if (!this.todo) {
+      const id = this.getValidatedId();
+      if (id === null) {
+        return;
+      }
+      this.loadTodo(id);
     }
-    this.loadTodo(id);
   }
 
   getValidatedId() {
@@ -52,17 +46,17 @@ export class TodoCardComponent implements OnInit {
     });
   }
 
-  toggleComplete(){
-    this.todo.isComplete = !this.todo.isComplete;
-    console.log(`Todo #${this.todo.id} marked as ${this.todo.isComplete ? 'complete' : 'incomplete'}`);
+  toggleComplete() {
+    if( this.todo){
+      this.todo.isComplete = !this.todo.isComplete;
+      console.log(`Todo #${this.todo.id} marked as ${this.todo.isComplete ? 'complete' : 'incomplete'}`);
+    }
   }
 
-  deleteTodo(){
-    console.log(`Todo #${this.todo.id} marked as deleted`);
-  }
-
-  navigateToList(){
-    this.router.navigateByUrl('/todos');
+  deleteTodo() {
+    if( this.todo){
+      console.log(`Todo #${this.todo.id} marked as deleted`);
+    }
   }
 }
 

--- a/frontend/src/app/todo-list/todo-list.component.html
+++ b/frontend/src/app/todo-list/todo-list.component.html
@@ -1,11 +1,12 @@
-<div class="container mt-5">
+<div class="album py-5 bg-body-tertiary">
+  <div class="container">
     <h1 class="text-center mb-4">{{ listName }}</h1>
-    <ul class="list-group">
+    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-5">
       @for (todo of todos; track todo.id) {
-      <li class="list-group-item d-flex justify-content-between align-items-center">
-        <span><strong>ID:</strong> {{todo.id}} - <strong>Title:</strong> {{todo.title}}</span>
-        <button class="btn btn-sm btn-danger" (click)="deleteTodo(todo.id)">Delete</button>
-      </li>
+        <div class="col d-flex justify-content-center">
+          <app-todo-card [todo]="todo" [isInList]="true" class="shadow-sm"></app-todo-card>
+        </div>
       }
-    </ul>
+    </div>
   </div>
+</div>

--- a/frontend/src/app/todo-list/todo-list.component.spec.ts
+++ b/frontend/src/app/todo-list/todo-list.component.spec.ts
@@ -76,13 +76,4 @@ describe('ListComponent', () => {
       message: jasmine.stringMatching(/Http failure response for undefined\/api\/todo: 500 Server Error/),
     }));
   });
-
-  it('should log a message when deleteTodo is called', () => {
-    spyOn(console, 'log');
-    const todoId = 1;
-
-    component.deleteTodo(todoId);
-
-    expect(console.log).toHaveBeenCalledWith(`delete button pressed for todo #${todoId}`);
-  });
 });

--- a/frontend/src/app/todo-list/todo-list.component.ts
+++ b/frontend/src/app/todo-list/todo-list.component.ts
@@ -3,10 +3,11 @@ import { Component, inject, OnInit } from '@angular/core';
 import { environment } from '../../environments/environment';
 import { TodoService } from '../_services/todo.service';
 import { Todo } from '../_models/todo';
+import { TodoCardComponent } from "../todo-card/todo-card.component";
 
 @Component({
   selector: 'app-todo-list',
-  imports: [],
+  imports: [TodoCardComponent],
   templateUrl: './todo-list.component.html',
   styleUrl: './todo-list.component.css'
 })
@@ -25,9 +26,5 @@ export class TodoListComponent implements OnInit {
       error: error => console.log(error),
       complete: () => console.log('Request has completed')
     })
-  }
-
-  deleteTodo(id: number) {
-    console.log("delete button pressed for todo #" + id);
   }
 }


### PR DESCRIPTION
- added isInListinput to differentiate between standalone cards and cards in the list.
- list now creates cards for each todo in todo's
- Title on card in list is clickable and leads to todos/id
- when a todo is in the list its title length is restricted but when not in list it is not.
- was able to remove the need for the dummy todo by creating the todo input 