### PR TITLE
filter select added to todo list

### DIFF
--- a/frontend/src/app/_models/todo-filter.ts
+++ b/frontend/src/app/_models/todo-filter.ts
@@ -1,0 +1,6 @@
+export enum TodoFilter {
+    All = 'all',
+    Deleted = 'deleted',
+    Completed = 'completed',
+    Incomplete = 'incomplete',
+  }

--- a/frontend/src/app/todo-card/todo-card.component.ts
+++ b/frontend/src/app/todo-card/todo-card.component.ts
@@ -58,6 +58,9 @@ export class TodoCardComponent implements OnInit {
         next: () => {
           this.todo!.isComplete = nextIsComplete;
           console.log(`Todo #${this.todo!.id} marked as ${this.todo!.isComplete ? 'complete' : 'incomplete'}`);
+          if (this.isInList) {
+            this.todoService.triggerListUpdate();
+          }
         },
         error: (error) => {
           console.error('Error updating todo:', error);

--- a/frontend/src/app/todo-list/todo-list.component.html
+++ b/frontend/src/app/todo-list/todo-list.component.html
@@ -1,11 +1,25 @@
 <div class="album py-5 bg-body-tertiary">
   <div class="container">
-    <h1 class="text-center mb-4 fw-light">{{ listName }}</h1>
+    <div class="row">
+      <div class="col text-end mb-2">
+        <select (change)="changeFilter($event)" class="form-select w-auto d-inline">
+          <option value="all" [selected]="currentFilter === 'all'">All</option>
+          <option value="deleted" [selected]="currentFilter === 'deleted'">Deleted</option>
+          <option value="completed" [selected]="currentFilter === 'completed'">Completed</option>
+          <option value="incomplete" [selected]="currentFilter === 'incomplete'">Incomplete</option>
+        </select>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col text-center">
+        <h1 class="fw-light">{{listName}}</h1>
+      </div>
+    </div>
     <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-5">
       @for (todo of visibleTodos; track todo.id) {
-        <div class="col d-flex justify-content-center">
-          <app-todo-card [todo]="todo" [isInList]="true" class="shadow-sm"></app-todo-card>
-        </div>
+      <div class="col d-flex justify-content-center">
+        <app-todo-card [todo]="todo" [isInList]="true" class="shadow-sm"></app-todo-card>
+      </div>
       }
     </div>
   </div>

--- a/frontend/src/app/todo-list/todo-list.component.html
+++ b/frontend/src/app/todo-list/todo-list.component.html
@@ -4,9 +4,9 @@
       <div class="col text-end mb-2">
         <select (change)="changeFilter($event)" class="form-select w-auto d-inline">
           <option value="all" [selected]="currentFilter === 'all'">All</option>
-          <option value="deleted" [selected]="currentFilter === 'deleted'">Deleted</option>
           <option value="completed" [selected]="currentFilter === 'completed'">Completed</option>
           <option value="incomplete" [selected]="currentFilter === 'incomplete'">Incomplete</option>
+          <option value="deleted" [selected]="currentFilter === 'deleted'">Deleted</option>
         </select>
       </div>
     </div>

--- a/frontend/src/app/todo-list/todo-list.component.spec.ts
+++ b/frontend/src/app/todo-list/todo-list.component.spec.ts
@@ -5,6 +5,7 @@ import { environment } from '../../environments/environment';
 import { Todo } from '../_models/todo';
 import { of } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
+import { TodoFilter } from '../_models/todo-filter';
 
 describe('ListComponent', () => {
   let component: TodoListComponent;
@@ -94,21 +95,21 @@ describe('ListComponent', () => {
       { id: 3, title: 'Todo 3', isComplete: false, isDeleted: true },
     ] as Todo[];
 
-    component.currentFilter = 'all';
+    component.currentFilter = TodoFilter.All;
     component.filterTodos();
     expect(component.visibleTodos.length).toBe(2);
 
-    component.currentFilter = 'completed';
+    component.currentFilter = TodoFilter.Completed;
     component.filterTodos();
     expect(component.visibleTodos.length).toBe(1);
     expect(component.visibleTodos[0].id).toBe(2);
 
-    component.currentFilter = 'incomplete';
+    component.currentFilter = TodoFilter.Incomplete;
     component.filterTodos();
     expect(component.visibleTodos.length).toBe(1);
     expect(component.visibleTodos[0].id).toBe(1);
 
-    component.currentFilter = 'deleted';
+    component.currentFilter = TodoFilter.Deleted;
     component.filterTodos();
     expect(component.visibleTodos.length).toBe(1);
     expect(component.visibleTodos[0].id).toBe(3);

--- a/frontend/src/app/todo-list/todo-list.component.spec.ts
+++ b/frontend/src/app/todo-list/todo-list.component.spec.ts
@@ -3,16 +3,26 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { TodoListComponent } from './todo-list.component';
 import { environment } from '../../environments/environment';
 import { Todo } from '../_models/todo';
+import { of } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
 
 describe('ListComponent', () => {
   let component: TodoListComponent;
   let httpMock: HttpTestingController;
+  let mockActivatedRoute: any;
 
   beforeEach(() => {
+    mockActivatedRoute = {
+      queryParams: of({}),
+    };
+
     TestBed.configureTestingModule({
       imports: [
-        HttpClientTestingModule, // Import the testing module for HttpClient
-        TodoListComponent,          // Import the standalone component
+        HttpClientTestingModule,
+        TodoListComponent,
+      ],
+      providers: [
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
       ],
     });
 
@@ -22,7 +32,7 @@ describe('ListComponent', () => {
   });
 
   afterEach(() => {
-    httpMock.verify(); // Ensure no outstanding HTTP requests
+    httpMock.verify();
   });
 
   it('should create the component', () => {
@@ -34,22 +44,22 @@ describe('ListComponent', () => {
   });
 
   it('should fetch todos on initialization', () => {
-  const mockTodos: Todo [] = [
-        {
-          id: 1, title: 'Todo 1',
-          created: new Date(2099, 0, 1),
-          updated: null,
-          isComplete: false,
-          isDeleted: false
-        },
-        {
-          id: 2, title: 'Todo 2',
-          created: new Date(2099, 0, 1),
-          updated: null,
-          isComplete: false,
-          isDeleted: false
-        },
-      ];
+    const mockTodos: Todo[] = [
+      {
+        id: 1, title: 'Todo 1',
+        created: new Date(2099, 0, 1),
+        updated: null,
+        isComplete: false,
+        isDeleted: false
+      },
+      {
+        id: 2, title: 'Todo 2',
+        created: new Date(2099, 0, 1),
+        updated: null,
+        isComplete: false,
+        isDeleted: false
+      },
+    ];
 
     component.ngOnInit();
 
@@ -76,4 +86,56 @@ describe('ListComponent', () => {
       message: jasmine.stringMatching(/Http failure response for undefined\/api\/todo: 500 Server Error/),
     }));
   });
+
+  it('should filter todos correctly based on the current filter', () => {
+    component.allTodos = [
+      { id: 1, title: 'Todo 1', isComplete: false, isDeleted: false },
+      { id: 2, title: 'Todo 2', isComplete: true, isDeleted: false },
+      { id: 3, title: 'Todo 3', isComplete: false, isDeleted: true },
+    ] as Todo[];
+
+    component.currentFilter = 'all';
+    component.filterTodos();
+    expect(component.visibleTodos.length).toBe(2);
+
+    component.currentFilter = 'completed';
+    component.filterTodos();
+    expect(component.visibleTodos.length).toBe(1);
+    expect(component.visibleTodos[0].id).toBe(2);
+
+    component.currentFilter = 'incomplete';
+    component.filterTodos();
+    expect(component.visibleTodos.length).toBe(1);
+    expect(component.visibleTodos[0].id).toBe(1);
+
+    component.currentFilter = 'deleted';
+    component.filterTodos();
+    expect(component.visibleTodos.length).toBe(1);
+    expect(component.visibleTodos[0].id).toBe(3);
+  });
+
+  it('should navigate with the selected filter when the dropdown value is changed', () => {
+    const routerSpy = spyOn(component['router'], 'navigate');
+    const mockEvent = {
+      target: { value: 'completed' }
+    } as unknown as Event;
+
+    component.changeFilter(mockEvent);
+
+    expect(routerSpy).toHaveBeenCalledWith(['/todos'], { queryParams: { filter: 'completed' } });
+  });
+
+  it('should default to "all" filter if no query parameter is provided', () => {
+
+    mockActivatedRoute.queryParams = of({});
+
+    component.ngOnInit();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/api/todo`);
+    req.flush([]);
+
+    expect(component.currentFilter).toBe('all');
+    expect(component.visibleTodos).toEqual([]);
+  });
+
 });

--- a/frontend/src/app/todo-list/todo-list.component.ts
+++ b/frontend/src/app/todo-list/todo-list.component.ts
@@ -3,6 +3,7 @@ import { TodoService } from '../_services/todo.service';
 import { Todo } from '../_models/todo';
 import { TodoCardComponent } from "../todo-card/todo-card.component";
 import { ActivatedRoute, Router } from '@angular/router';
+import { TodoFilter } from '../_models/todo-filter';
 
 @Component({
   selector: 'app-todo-list',
@@ -18,11 +19,11 @@ export class TodoListComponent implements OnInit {
   listName = "Your Current todo list";
   allTodos: Todo[] = [];
   visibleTodos: Todo[] = [];
-  currentFilter: string = 'all';
+  currentFilter: TodoFilter = TodoFilter.All;
 
   ngOnInit(): void {
     this.route.queryParams.subscribe(params => {
-      this.currentFilter = params['filter'] || 'all';
+      this.currentFilter = params['filter'] as TodoFilter|| TodoFilter.All;
       this.loadTodos();
     });
 
@@ -45,15 +46,15 @@ export class TodoListComponent implements OnInit {
 
   filterTodos() {
     switch (this.currentFilter) {
-      case 'deleted':
+      case TodoFilter.Deleted:
         this.visibleTodos = this.allTodos.filter(todo => todo.isDeleted);
         this.listName = "Deleted Todos";
         break;
-      case 'completed':
+      case TodoFilter.Completed:
         this.visibleTodos = this.allTodos.filter(todo => todo.isComplete && !todo.isDeleted);
         this.listName = "Completed Todos";
         break;
-      case 'incomplete':
+      case TodoFilter.Incomplete:
         this.visibleTodos = this.allTodos.filter(todo => !todo.isComplete && !todo.isDeleted);
         this.listName = "Incomplete Todos";
         break;
@@ -65,7 +66,7 @@ export class TodoListComponent implements OnInit {
   }
 
   changeFilter(event: Event) {
-    const selectedFilter = (event.target as HTMLSelectElement).value;
+    const selectedFilter = (event.target as HTMLSelectElement).value as TodoFilter;
     this.router.navigate(['/todos'], { queryParams: { filter: selectedFilter } });
   }
 }

--- a/frontend/src/app/todo-list/todo-list.component.ts
+++ b/frontend/src/app/todo-list/todo-list.component.ts
@@ -1,9 +1,8 @@
-import { HttpClient } from '@angular/common/http';
 import { Component, inject, OnInit } from '@angular/core';
-import { environment } from '../../environments/environment';
 import { TodoService } from '../_services/todo.service';
 import { Todo } from '../_models/todo';
 import { TodoCardComponent } from "../todo-card/todo-card.component";
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'app-todo-list',
@@ -13,22 +12,31 @@ import { TodoCardComponent } from "../todo-card/todo-card.component";
 })
 export class TodoListComponent implements OnInit {
   private todoService = inject(TodoService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+
   listName = "Your Current todo list";
   allTodos: Todo[] = [];
   visibleTodos: Todo[] = [];
-  
+  currentFilter: string = 'all';
+
   ngOnInit(): void {
-    this.loadTodos();
+    this.route.queryParams.subscribe(params => {
+      this.currentFilter = params['filter'] || 'all';
+      this.loadTodos();
+    });
+
     this.todoService.todoListUpdated.subscribe(() => {
       this.filterTodos();
     });
   }
 
-  loadTodos(){
+
+  loadTodos() {
     this.todoService.getAllTodos().subscribe({
       next: todos => {
         this.allTodos = todos;
-        this.filterTodos(); 
+        this.filterTodos();
       },
       error: error => console.log(error),
       complete: () => console.log('Request has completed')
@@ -36,6 +44,28 @@ export class TodoListComponent implements OnInit {
   }
 
   filterTodos() {
-    this.visibleTodos = this.allTodos.filter(todo => !todo.isDeleted);
+    switch (this.currentFilter) {
+      case 'deleted':
+        this.visibleTodos = this.allTodos.filter(todo => todo.isDeleted);
+        this.listName = "Deleted Todos";
+        break;
+      case 'completed':
+        this.visibleTodos = this.allTodos.filter(todo => todo.isComplete && !todo.isDeleted);
+        this.listName = "Completed Todos";
+        break;
+      case 'incomplete':
+        this.visibleTodos = this.allTodos.filter(todo => !todo.isComplete && !todo.isDeleted);
+        this.listName = "Incomplete Todos";
+        break;
+      default:
+        this.visibleTodos = this.allTodos.filter(todo => !todo.isDeleted);
+        this.listName = "Your Current Todo List";
+        break;
+    }
+  }
+
+  changeFilter(event: Event) {
+    const selectedFilter = (event.target as HTMLSelectElement).value;
+    this.router.navigate(['/todos'], { queryParams: { filter: selectedFilter } });
   }
 }


### PR DESCRIPTION
-  Added a `currentFilter `string variable
-  Added Filter query parameter to url (EX: `todos?filter=completed` )
-  Updated `currentFilter` to the filter value specified in query params, with default value of all 
-  Updated `filterTodos()` function to filter `visibleTodos `based on `currentFilter`.
- Added dropdown selector to html with options for changing the `currentFilter `by calling new function `changeFilter(event)`


![Screenshot 2025-02-06 122149](https://github.com/user-attachments/assets/77f0a73c-5e2b-4d0b-9137-e33c92576f3c)
![Screenshot 2025-02-06 122158](https://github.com/user-attachments/assets/c893fbef-ec47-4c95-8c78-cac7988343a4)
![Screenshot 2025-02-06 122205](https://github.com/user-attachments/assets/28299621-c8c9-4ed2-bc08-c5e2ccc7e743)


### Updated PR:

- added new `TodoFilter` object suggested in the comment.
- Put delete last in the dropdown.
- Updated `toggleComplete()` to update the list so completing a todo while on the incomplete filtered list removes that todo.